### PR TITLE
ADD -  UUID variable to stay consistent and fallback to random gen if…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,9 @@
 FROM alpine
+# Update and Upgrade automatically without prompt
+RUN apk update && apk upgrade
 RUN apk add --no-cache ca-certificates dbus wget
+# Delete cache and temp files to reduce image size
+RUN rm -rf /var/cache/apk/* /tmp/*
 ADD entrypoint.sh /root/
 RUN chmod +x /root/entrypoint.sh
 ENTRYPOINT [ "/root/entrypoint.sh" ]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -9,8 +9,18 @@ else
     echo "Unsupported architecture: $ARCH"
     exit 1
 fi
-# Generate a random uuid
-dbus-uuidgen > /etc/machine-id
+
+# Check if a SPEEDSHARE_UUID is provided as an environment variable, else gives a warning message and a new UUID is generated
+if [ -z "$SPEEDSHARE_UUID" ]; then
+    echo "Warning: No UUID provided. A new random UUID will be generated"
+    echo "This will cause the device to be seen as a new device in the SpeedShare app every time it is restarted."
+    echo "To avoid this, please provide a UUID as an environment variable."
+    dbus-uuidgen > /etc/machine-id
+else
+    echo "$SPEEDSHARE_UUID" > /etc/machine-id
+    echo "UUID provided: $SPEEDSHARE_UUID"
+fi
+
 # Download, install and run the program
 wget -q https://api.speedshare.app/download/linux/cli/$ARCH -O /root/SpeedShareCLI
 chmod +x /root/SpeedShareCLI


### PR DESCRIPTION
… no UUID passed in env vars part of issue #1 

ADD - SPPEDSHARE_UUID env variable and fallback to random UUID if not set 
- This ensures that the specified SPEEDSHARE_UUID is used each time the container is started, allowing for a consistent device identity across restarts and updates